### PR TITLE
[FE-8602] forces overflow data into last bin

### DIFF
--- a/packages/data-layer/src/parser/parse-bin.js
+++ b/packages/data-layer/src/parser/parse-bin.js
@@ -7,8 +7,7 @@ export default function parseBin(
 ): SQL {
   sql.select.push(
     `case when
-      cast((cast(${field} as float) - ${extent[0]}) * ${maxbins /
-      (extent[1] - extent[0])} as int) >= ${maxbins}
+      ${field} >= ${extent[1]}
     then
       ${maxbins - 1}
     else

--- a/packages/data-layer/src/parser/parse-bin.js
+++ b/packages/data-layer/src/parser/parse-bin.js
@@ -6,10 +6,21 @@ export default function parseBin(
   { field, as, extent, maxbins }: Bin
 ): SQL {
   sql.select.push(
-    `cast((cast(${field} as float) - ${extent[0]}) * ${maxbins / (extent[1] - extent[0])} as int) as ${as}`
+    `case when
+      cast((cast(${field} as float) - ${extent[0]}) * ${maxbins /
+      (extent[1] - extent[0])} as int) >= ${maxbins}
+    then
+      ${maxbins - 1}
+    else
+      cast((cast(${field} as float) - ${extent[0]}) * ${maxbins /
+      (extent[1] - extent[0])} as int)
+    end
+    as ${as}`
   );
   sql.where.push(
-    `((${field} >= ${extent[0]} AND ${field} <= ${extent[1]}) OR (${field} IS NULL))`
+    `((${field} >= ${extent[0]} AND ${field} <= ${
+      extent[1]
+    }) OR (${field} IS NULL))`
   );
   sql.having.push(`(${as} >= 0 AND ${as} < ${maxbins} OR ${as} IS NULL)`);
   return sql;

--- a/packages/data-layer/tests/integration.spec.js
+++ b/packages/data-layer/tests/integration.spec.js
@@ -80,7 +80,7 @@ tape("Integration Test", assert => {
 
   assert.equal(
     chartNode2.toSQL(),
-    "SELECT cast((cast(trip_distance as float) - 0) * 1 as int) as key0, COUNT(*) as val FROM flights WHERE ((trip_distance >= 0 AND trip_distance <= 30) OR (trip_distance IS NULL)) GROUP BY key0 HAVING (key0 >= 0 AND key0 < 30 OR key0 IS NULL)"
+    "SELECT case when\n      trip_distance >= 30\n    then\n      29\n    else\n      cast((cast(trip_distance as float) - 0) * 1 as int)\n    end\n    as key0, COUNT(*) as val FROM flights WHERE ((trip_distance >= 0 AND trip_distance <= 30) OR (trip_distance IS NULL)) GROUP BY key0 HAVING (key0 >= 0 AND key0 < 30 OR key0 IS NULL)"
   );
 
   globalFilterNode.transform(
@@ -162,6 +162,6 @@ tape("Integration Test", assert => {
 
   assert.equal(
     chartNode2.toSQL(),
-    "SELECT cast((cast(trip_distance as float) - 0) * 1 as int) as key0, COUNT(*) as val FROM flights WHERE ((trip_distance >= 0 AND trip_distance <= 30) OR (trip_distance IS NULL)) AND (payment_type = 'cash') AND (dropoff_longitude BETWEEN -73.99828105055514 AND -73.7766089742046) AND (dropoff_latitude BETWEEN 40.63646686110235 AND 40.81468768513369) GROUP BY key0 HAVING (key0 >= 0 AND key0 < 30 OR key0 IS NULL)"
+    "SELECT case when\n      trip_distance >= 30\n    then\n      29\n    else\n      cast((cast(trip_distance as float) - 0) * 1 as int)\n    end\n    as key0, COUNT(*) as val FROM flights WHERE ((trip_distance >= 0 AND trip_distance <= 30) OR (trip_distance IS NULL)) AND (payment_type = \'cash\') AND (dropoff_longitude BETWEEN -73.99828105055514 AND -73.7766089742046) AND (dropoff_latitude BETWEEN 40.63646686110235 AND 40.81468768513369) GROUP BY key0 HAVING (key0 >= 0 AND key0 < 30 OR key0 IS NULL)"
   );
 });

--- a/packages/data-layer/tests/parser/parse-expression.spec.js
+++ b/packages/data-layer/tests/parser/parse-expression.spec.js
@@ -285,6 +285,6 @@ assert.equal(
         }
       ]
     }),
-    "(SELECT cast((cast(total_amount as float) - -21474830) * 4.719682036909046e-7 as int) as key0, COUNT(*) as series_1 FROM taxis WHERE ((total_amount >= -21474830 AND total_amount <= 3950611.6) OR (total_amount IS NULL)) GROUP BY key0 HAVING (key0 >= 0 AND key0 < 12 OR key0 IS NULL))"
+    "(SELECT case when\n      total_amount >= 3950611.6\n    then\n      11\n    else\n      cast((cast(total_amount as float) - -21474830) * 4.719682036909046e-7 as int)\n    end\n    as key0, COUNT(*) as series_1 FROM taxis WHERE ((total_amount >= -21474830 AND total_amount <= 3950611.6) OR (total_amount IS NULL)) GROUP BY key0 HAVING (key0 >= 0 AND key0 < 12 OR key0 IS NULL))"
   );
 });

--- a/packages/data-layer/tests/parser/parse-transform.spec.js
+++ b/packages/data-layer/tests/parser/parse-transform.spec.js
@@ -53,7 +53,7 @@ tape("parseDataState", assert => {
     }),
     {
       select: [
-        "cast((cast(total_amount as float) - -21474830) * 4.719682036909046e-7 as int) as key0",
+        "case when\n      total_amount >= 3950611.6\n    then\n      11\n    else\n      cast((cast(total_amount as float) - -21474830) * 4.719682036909046e-7 as int)\n    end\n    as key0",
         "COUNT(*) as series_1"
       ],
       from: "taxis",
@@ -97,7 +97,7 @@ tape("bin", assert => {
     ),
     {
       select: [
-        "cast((cast(airtime as float) - 0) * 0.008888888888888889 as int) as key0"
+        "case when\n      airtime >= 1350\n    then\n      11\n    else\n      cast((cast(airtime as float) - 0) * 0.008888888888888889 as int)\n    end\n    as key0"
       ],
       from: "",
       where: ["((airtime >= 0 AND airtime <= 1350) OR (airtime IS NULL))"],

--- a/packages/data-layer/tests/parser/write-sql.spec.js
+++ b/packages/data-layer/tests/parser/write-sql.spec.js
@@ -96,7 +96,7 @@ tape("writeSQL", assert => {
         }
       ]
     }),
-    "SELECT cast((cast(airtime as float) - -3818) * 0.001638001638001638 as int) as key0, cast((cast(distance as float) - 0) * 0.002408187838651415 as int) as key1, COUNT(*) as val FROM flights WHERE ((airtime >= -3818 AND airtime <= 3508) OR (airtime IS NULL)) AND ((distance >= 0 AND distance <= 4983) OR (distance IS NULL)) GROUP BY key0, key1 HAVING (key0 >= 0 AND key0 < 12 OR key0 IS NULL) AND (key1 >= 0 AND key1 < 12 OR key1 IS NULL) ORDER BY val DESC LIMIT 10"
+    "SELECT case when\n      airtime >= 3508\n    then\n      11\n    else\n      cast((cast(airtime as float) - -3818) * 0.001638001638001638 as int)\n    end\n    as key0, case when\n      distance >= 4983\n    then\n      11\n    else\n      cast((cast(distance as float) - 0) * 0.002408187838651415 as int)\n    end\n    as key1, COUNT(*) as val FROM flights WHERE ((airtime >= -3818 AND airtime <= 3508) OR (airtime IS NULL)) AND ((distance >= 0 AND distance <= 4983) OR (distance IS NULL)) GROUP BY key0, key1 HAVING (key0 >= 0 AND key0 < 12 OR key0 IS NULL) AND (key1 >= 0 AND key1 < 12 OR key1 IS NULL) ORDER BY val DESC LIMIT 10"
   );
 
   assert.equal(


### PR DESCRIPTION
References: [FE-8602](https://jira.omnisci.com/browse/FE-8602)

Okay, so there was a glitch in binning. The short version is that data at or towards the upper bounds of the data selection would be omitted from the last bin. Floating point issues could've exacerbated the problem, but were NOT the root cause.

For an example, consider the pokemon table with a dimension of attack and 12 bins. The max attack value is 190, but the last bin ends up being calculated as [174.5833333 -> 189.9999997].

The SQL statement to do the binning was:

cast((cast(${field} as float) - ${extent[0]}) * ${maxbins / (extent[1] - extent[0])} as int) >= ${maxbins}

And in the Pokemon case turned into:

cast((cast(Attack as float) - 5) * 0.06486486486486487 as int) >= 12

The magic number ( 0.064864864...) comes from 12 / 185 (the number of bins, divided by the range 190 - 5 = 185).

But if you applied that to the value at the boundary, 190, you'd get this:
(190 - 5) * 0.06486486486486487 as int = 12. However, since it's 12 bins the bin range goes from 0->11, and as a result this value would fall outside the last bin.

Suggestions were made to add 1 to the extent to force the last element into the last bin, but this won't work for a couple of reasons:
* Most importantly, it changes the bin size. So this will adjust which bins the other items get put into, when all we wanted was to properly populate the last bin. This effect becomes more dramatic the smaller the extent size or the fewer bins involved.
* It also potentially won't work with certain data sets - a very large extent (say 5,000,000) would only change to 5,000,001 and that probably isn't enough to for the last value into the last bin, due to FP precision.

So this change adds a very _very_ ugly case statement - it just says that if a value would've been binned off the top edge, that the value should instead be binned into the top bin. No other changes are made.

And ta da! Values at the edge of the range are now properly included in the top bin and nothing else is modified. It's an ugly fix, but mathematically correct.