### PR TITLE
[FE-8667] - avoids infinity error

### DIFF
--- a/packages/data-layer/src/parser/parse-bin.js
+++ b/packages/data-layer/src/parser/parse-bin.js
@@ -5,14 +5,16 @@ export default function parseBin(
   sql: SQL,
   { field, as, extent, maxbins }: Bin
 ): SQL {
+  const binRange = extent[1] - extent[0];
+  
   sql.select.push(
     `case when
       ${field} >= ${extent[1]}
     then
-      ${maxbins - 1}
+      ${ binRange === 0 ? 0 : maxbins - 1}
     else
       cast((cast(${field} as float) - ${extent[0]}) * ${maxbins /
-      ((extent[1] - extent[0]) || 1)} as int)
+      (binRange || 1) } as int)
     end
     as ${as}`
   );

--- a/packages/data-layer/src/parser/parse-bin.js
+++ b/packages/data-layer/src/parser/parse-bin.js
@@ -5,16 +5,26 @@ export default function parseBin(
   sql: SQL,
   { field, as, extent, maxbins }: Bin
 ): SQL {
-  const binRange = extent[1] - extent[0];
-  
+
+  // numBins is used conditionally in our query building below.
+  // first of all, if we're going to fall into the overflow bin AND we have
+  // 0 bins, then we should land in bin 0. Otherwise, we should land in the last
+  // bin.
+  //
+  // later, we calculate the binning magic number based on numBins - dividing either
+  // by it or 1 if it doesn't exist, to prevent a divide by zero / infinity error.
+  //
+  // The logic used by mapd-crossfilter's getBinnedDimExpression is completely different.
+  const numBins  = extent[1] - extent[0];
+
   sql.select.push(
     `case when
       ${field} >= ${extent[1]}
     then
-      ${ binRange === 0 ? 0 : maxbins - 1}
+      ${ numBins === 0 ? 0 : maxbins - 1}
     else
       cast((cast(${field} as float) - ${extent[0]}) * ${maxbins /
-      (binRange || 1) } as int)
+      (numBins || 1) } as int)
     end
     as ${as}`
   );

--- a/packages/data-layer/src/parser/parse-bin.js
+++ b/packages/data-layer/src/parser/parse-bin.js
@@ -12,7 +12,7 @@ export default function parseBin(
       ${maxbins - 1}
     else
       cast((cast(${field} as float) - ${extent[0]}) * ${maxbins /
-      (extent[1] - extent[0])} as int)
+      ((extent[1] - extent[0]) || 1)} as int)
     end
     as ${as}`
   );


### PR DESCRIPTION
### 💬  Description

If you created a chart with only a single bin (say you have a combo chart and accept a crossfilter from a bar chart, where the bar only fills a single bin in the combo, as per the ticket), you'd end up with an error -

parse-bins would attempt extent[1] - extent[0], which is just 0. It'd then divide by that, giving you "Infinity" (also wrong. But hey: Javascript), and then core would choke because Infinity doesn't exist in the table. It's very poetic.

This fix just bounds it so that if extent[1] == extent[0] is 0 (the error condition), to swap it out for 1. This has the effect of tossing all of the data into the "last" bin, which doesn't seem to have any negative impact on anything.


### 📄 Jira Issue

Closes [FE-8667](https://jira.omnisci.com/browse/FE-8667)

### :camera_flash: Screenshot


