### PR TITLE
[FE-8842] Normalize table and column alias SQL to use uppercase AS

### DIFF
--- a/examples/mapd-charting/src/crossfilter.js
+++ b/examples/mapd-charting/src/crossfilter.js
@@ -49,10 +49,10 @@ export const pointmapGroup = {
   },
   getProjectOn() {
     return [
-      "conv_4326_900913_x(lon) as x",
-      "conv_4326_900913_y(lat) as y",
-      "lang as color",
-      "followers as size"
+      "conv_4326_900913_x(lon) AS x",
+      "conv_4326_900913_y(lat) AS y",
+      "lang AS color",
+      "followers AS size"
     ];
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2606,13 +2606,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2629,19 +2631,22 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2772,7 +2777,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2786,6 +2792,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2802,6 +2809,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2810,13 +2818,15 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2837,6 +2847,7 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2925,7 +2936,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2939,6 +2951,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3076,6 +3089,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4856,6 +4870,7 @@
           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
           "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -6189,7 +6204,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
           "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "loose-envify": {
           "version": "1.3.1",

--- a/packages/data-layer/package-lock.json
+++ b/packages/data-layer/package-lock.json
@@ -1971,12 +1971,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1991,17 +1993,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2118,7 +2123,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2130,6 +2136,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2144,6 +2151,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2151,12 +2159,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2175,6 +2185,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2255,7 +2266,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2267,6 +2279,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2388,6 +2401,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/packages/data-layer/src/parser/parse-aggregate.js
+++ b/packages/data-layer/src/parser/parse-aggregate.js
@@ -42,7 +42,7 @@ function aggregateField(op: string, field: string, as: string): string {
     str += `${op}(${field})`;
   }
 
-  return str + `${as ? " as " + as : ""}`;
+  return str + `${as ? " AS " + as : ""}`;
 }
 
 function parseGroupBy(
@@ -59,7 +59,7 @@ function parseGroupBy(
   } else if (groupby.type === "project") {
     sql.select.push(
       parser.parseExpression(groupby.expr) +
-        (groupby.as ? " as " + groupby.as : "")
+        (groupby.as ? " AS " + groupby.as : "")
     );
     if (groupby.as) {
       sql.groupby.push(groupby.as);

--- a/packages/data-layer/src/parser/parse-bin.js
+++ b/packages/data-layer/src/parser/parse-bin.js
@@ -26,7 +26,7 @@ export default function parseBin(
       cast((cast(${field} as float) - ${extent[0]}) * ${maxbins /
       (numBins || 1) } as int)
     end
-    as ${as}`
+    AS ${as}`
   );
   sql.where.push(
     `((${field} >= ${extent[0]} AND ${field} <= ${

--- a/packages/data-layer/src/parser/parse-project.js
+++ b/packages/data-layer/src/parser/parse-project.js
@@ -10,7 +10,7 @@ export default function parseProject(
 ): SQL {
   sql.select.push(
     parser.parseExpression(transform.expr) +
-      (transform.as ? " as " + transform.as : "")
+      (transform.as ? " AS " + transform.as : "")
   );
   return sql;
 }

--- a/packages/data-layer/src/parser/parse-source.js
+++ b/packages/data-layer/src/parser/parse-source.js
@@ -47,7 +47,7 @@ export default function parseSource(
           // $FlowFixMe
           const joinStmt = left + " " + joinRelation(joinType) + " " + right;
           const aliasStmt = typeof transform.as === "string"
-            ? " as " + transform.as
+            ? " AS " + transform.as
             : "";
           return stmt.concat(joinStmt + aliasStmt);
         } else if (transform.type === "data" || transform.type === "root") {

--- a/packages/data-layer/tests/integration.spec.js
+++ b/packages/data-layer/tests/integration.spec.js
@@ -75,12 +75,12 @@ tape("Integration Test", assert => {
 
   assert.equal(
     chartNode1.toSQL(),
-    "SELECT payment_type as key0, COUNT(*) as val FROM flights GROUP BY key0 ORDER BY val ASC LIMIT 10"
+    "SELECT payment_type AS key0, COUNT(*) AS val FROM flights GROUP BY key0 ORDER BY val ASC LIMIT 10"
   );
 
   assert.equal(
     chartNode2.toSQL(),
-    "SELECT case when\n      trip_distance >= 30\n    then\n      29\n    else\n      cast((cast(trip_distance as float) - 0) * 1 as int)\n    end\n    as key0, COUNT(*) as val FROM flights WHERE ((trip_distance >= 0 AND trip_distance <= 30) OR (trip_distance IS NULL)) GROUP BY key0 HAVING (key0 >= 0 AND key0 < 30 OR key0 IS NULL)"
+    "SELECT case when\n      trip_distance >= 30\n    then\n      29\n    else\n      cast((cast(trip_distance as float) - 0) * 1 as int)\n    end\n    AS key0, COUNT(*) AS val FROM flights WHERE ((trip_distance >= 0 AND trip_distance <= 30) OR (trip_distance IS NULL)) GROUP BY key0 HAVING (key0 >= 0 AND key0 < 30 OR key0 IS NULL)"
   );
 
   globalFilterNode.transform(
@@ -157,11 +157,11 @@ tape("Integration Test", assert => {
 
   assert.equal(
     chartNode1.toSQL(),
-    "SELECT payment_type as key0, COUNT(*) as val FROM flights WHERE (trip_distance BETWEEN 12 AND 20) AND (dropoff_longitude BETWEEN -73.99828105055514 AND -73.7766089742046) AND (dropoff_latitude BETWEEN 40.63646686110235 AND 40.81468768513369) GROUP BY key0 ORDER BY val ASC LIMIT 10"
+    "SELECT payment_type AS key0, COUNT(*) AS val FROM flights WHERE (trip_distance BETWEEN 12 AND 20) AND (dropoff_longitude BETWEEN -73.99828105055514 AND -73.7766089742046) AND (dropoff_latitude BETWEEN 40.63646686110235 AND 40.81468768513369) GROUP BY key0 ORDER BY val ASC LIMIT 10"
   );
 
   assert.equal(
     chartNode2.toSQL(),
-    "SELECT case when\n      trip_distance >= 30\n    then\n      29\n    else\n      cast((cast(trip_distance as float) - 0) * 1 as int)\n    end\n    as key0, COUNT(*) as val FROM flights WHERE ((trip_distance >= 0 AND trip_distance <= 30) OR (trip_distance IS NULL)) AND (payment_type = \'cash\') AND (dropoff_longitude BETWEEN -73.99828105055514 AND -73.7766089742046) AND (dropoff_latitude BETWEEN 40.63646686110235 AND 40.81468768513369) GROUP BY key0 HAVING (key0 >= 0 AND key0 < 30 OR key0 IS NULL)"
+    "SELECT case when\n      trip_distance >= 30\n    then\n      29\n    else\n      cast((cast(trip_distance as float) - 0) * 1 as int)\n    end\n    AS key0, COUNT(*) AS val FROM flights WHERE ((trip_distance >= 0 AND trip_distance <= 30) OR (trip_distance IS NULL)) AND (payment_type = \'cash\') AND (dropoff_longitude BETWEEN -73.99828105055514 AND -73.7766089742046) AND (dropoff_latitude BETWEEN 40.63646686110235 AND 40.81468768513369) GROUP BY key0 HAVING (key0 >= 0 AND key0 < 30 OR key0 IS NULL)"
   );
 });

--- a/packages/data-layer/tests/parser/parse-aggregate.spec.js
+++ b/packages/data-layer/tests/parser/parse-aggregate.spec.js
@@ -45,9 +45,9 @@ tape("aggregate", assert => {
     ),
     {
       select: [
-        "date_trunc(day, dep_timestamp) as x",
-        "extract(month from dep_timestamp) as z",
-        "COUNT(*) as y"
+        "date_trunc(day, dep_timestamp) AS x",
+        "extract(month from dep_timestamp) AS z",
+        "COUNT(*) AS y"
       ],
       from: "",
       where: [],
@@ -87,7 +87,7 @@ tape("aggregate", assert => {
       }
     ),
     {
-      select: ["date_trunc(day, dep_timestamp) as x", "COUNT(*) as y"],
+      select: ["date_trunc(day, dep_timestamp) AS x", "COUNT(*) AS y"],
       from: "",
       where: [],
       groupby: ["x"],
@@ -118,7 +118,7 @@ tape("aggregate", assert => {
       }
     ),
     {
-      select: ["party", "COUNT(*) as key0"],
+      select: ["party", "COUNT(*) AS key0"],
       from: "",
       where: [],
       groupby: ["party"],
@@ -152,8 +152,8 @@ tape("aggregate", assert => {
       select: [
         "city",
         "state",
-        "AVG(airtime) as val",
-        "COUNT(depdelay) as color"
+        "AVG(airtime) AS val",
+        "COUNT(depdelay) AS color"
       ],
       from: "",
       where: [],
@@ -185,7 +185,7 @@ tape("aggregate", assert => {
       }
     ),
     {
-      select: ["carrier", "SUM(airtime) as val", "MIN(depdelay) as color"],
+      select: ["carrier", "SUM(airtime) AS val", "MIN(depdelay) AS color"],
       from: "",
       where: [],
       groupby: ["carrier"],

--- a/packages/data-layer/tests/parser/parse-expression.spec.js
+++ b/packages/data-layer/tests/parser/parse-expression.spec.js
@@ -189,7 +189,7 @@ tape("parseExpression", assert => {
       ],
       else: "other"
     }),
-    "CASE WHEN recipient_party IN (SELECT recipient_party, MAX(amount) as val FROM contributions GROUP BY recipient_party LIMIT 10) THEN recipient_party ELSE 'other' END"
+    "CASE WHEN recipient_party IN (SELECT recipient_party, MAX(amount) AS val FROM contributions GROUP BY recipient_party LIMIT 10) THEN recipient_party ELSE 'other' END"
   );
 
 assert.equal(
@@ -223,7 +223,7 @@ assert.equal(
         ]
       ]
     }),
-    "CASE WHEN recipient_party IN (SELECT recipient_party, MAX(amount) as val FROM contributions GROUP BY recipient_party LIMIT 10) THEN recipient_party END"
+    "CASE WHEN recipient_party IN (SELECT recipient_party, MAX(amount) AS val FROM contributions GROUP BY recipient_party LIMIT 10) THEN recipient_party END"
   );
 
   // case statement may be constructed from a set array, single quotes should be escaped as two single quotes
@@ -285,6 +285,6 @@ assert.equal(
         }
       ]
     }),
-    "(SELECT case when\n      total_amount >= 3950611.6\n    then\n      11\n    else\n      cast((cast(total_amount as float) - -21474830) * 4.719682036909046e-7 as int)\n    end\n    as key0, COUNT(*) as series_1 FROM taxis WHERE ((total_amount >= -21474830 AND total_amount <= 3950611.6) OR (total_amount IS NULL)) GROUP BY key0 HAVING (key0 >= 0 AND key0 < 12 OR key0 IS NULL))"
+    "(SELECT case when\n      total_amount >= 3950611.6\n    then\n      11\n    else\n      cast((cast(total_amount as float) - -21474830) * 4.719682036909046e-7 as int)\n    end\n    AS key0, COUNT(*) AS series_1 FROM taxis WHERE ((total_amount >= -21474830 AND total_amount <= 3950611.6) OR (total_amount IS NULL)) GROUP BY key0 HAVING (key0 >= 0 AND key0 < 12 OR key0 IS NULL))"
   );
 });

--- a/packages/data-layer/tests/parser/parse-project.spec.js
+++ b/packages/data-layer/tests/parser/parse-project.spec.js
@@ -53,7 +53,7 @@ tape("parseProject", assert => {
       }
     ),
     {
-      select: ["AVG(amount) as val"],
+      select: ["AVG(amount) AS val"],
       from: "",
       where: [],
       groupby: [],
@@ -87,7 +87,7 @@ tape("parseProject", assert => {
       }
     ),
     {
-      select: ["date_trunc(quarter, contrib_date) as key0"],
+      select: ["date_trunc(quarter, contrib_date) AS key0"],
       from: "",
       where: [],
       groupby: [],
@@ -121,7 +121,7 @@ tape("parseProject", assert => {
       }
     ),
     {
-      select: ["extract(day from contrib_date) as key0"],
+      select: ["extract(day from contrib_date) AS key0"],
       from: "",
       where: [],
       groupby: [],
@@ -165,7 +165,7 @@ tape("parseProject", assert => {
     ),
     {
       select: [
-        "CASE WHEN recipient_party IN ('R', 'D', 'I', '3', 'L') THEN recipient_party ELSE 'other' END as key1"
+        "CASE WHEN recipient_party IN ('R', 'D', 'I', '3', 'L') THEN recipient_party ELSE 'other' END AS key1"
       ],
       from: "",
       where: [],

--- a/packages/data-layer/tests/parser/parse-source.spec.js
+++ b/packages/data-layer/tests/parser/parse-source.spec.js
@@ -27,7 +27,7 @@ tape("parseSource", assert => {
         as: "table2"
       }
     ]),
-    "flights JOIN zipcode as table1 RIGHT JOIN contrib as table2"
+    "flights JOIN zipcode AS table1 RIGHT JOIN contrib AS table2"
   );
 
   assert.deepEqual(
@@ -63,6 +63,6 @@ tape("parseSource", assert => {
         as: "table2"
       }
     ]),
-    "flights INNER JOIN zipcode as table1 LEFT JOIN (SELECT dest_city, AVG(depdelay) as val FROM flights GROUP BY dest_city) as table2"
+    "flights INNER JOIN zipcode AS table1 LEFT JOIN (SELECT dest_city, AVG(depdelay) AS val FROM flights GROUP BY dest_city) AS table2"
   );
 });

--- a/packages/data-layer/tests/parser/parse-transform.spec.js
+++ b/packages/data-layer/tests/parser/parse-transform.spec.js
@@ -53,8 +53,8 @@ tape("parseDataState", assert => {
     }),
     {
       select: [
-        "case when\n      total_amount >= 3950611.6\n    then\n      11\n    else\n      cast((cast(total_amount as float) - -21474830) * 4.719682036909046e-7 as int)\n    end\n    as key0",
-        "COUNT(*) as series_1"
+        "case when\n      total_amount >= 3950611.6\n    then\n      11\n    else\n      cast((cast(total_amount as float) - -21474830) * 4.719682036909046e-7 as int)\n    end\n    AS key0",
+        "COUNT(*) AS series_1"
       ],
       from: "taxis",
       where: [
@@ -97,7 +97,7 @@ tape("bin", assert => {
     ),
     {
       select: [
-        "case when\n      airtime >= 1350\n    then\n      11\n    else\n      cast((cast(airtime as float) - 0) * 0.008888888888888889 as int)\n    end\n    as key0"
+        "case when\n      airtime >= 1350\n    then\n      11\n    else\n      cast((cast(airtime as float) - 0) * 0.008888888888888889 as int)\n    end\n    AS key0"
       ],
       from: "",
       where: ["((airtime >= 0 AND airtime <= 1350) OR (airtime IS NULL))"],

--- a/packages/data-layer/tests/parser/write-sql.spec.js
+++ b/packages/data-layer/tests/parser/write-sql.spec.js
@@ -36,7 +36,7 @@ tape("writeSQL", assert => {
         }
       ]
     }),
-    "SELECT dest_city, AVG(depdelay) as val FROM flights GROUP BY dest_city"
+    "SELECT dest_city, AVG(depdelay) AS val FROM flights GROUP BY dest_city"
   );
 
   assert.equal(
@@ -96,7 +96,7 @@ tape("writeSQL", assert => {
         }
       ]
     }),
-    "SELECT case when\n      airtime >= 3508\n    then\n      11\n    else\n      cast((cast(airtime as float) - -3818) * 0.001638001638001638 as int)\n    end\n    as key0, case when\n      distance >= 4983\n    then\n      11\n    else\n      cast((cast(distance as float) - 0) * 0.002408187838651415 as int)\n    end\n    as key1, COUNT(*) as val FROM flights WHERE ((airtime >= -3818 AND airtime <= 3508) OR (airtime IS NULL)) AND ((distance >= 0 AND distance <= 4983) OR (distance IS NULL)) GROUP BY key0, key1 HAVING (key0 >= 0 AND key0 < 12 OR key0 IS NULL) AND (key1 >= 0 AND key1 < 12 OR key1 IS NULL) ORDER BY val DESC LIMIT 10"
+    "SELECT case when\n      airtime >= 3508\n    then\n      11\n    else\n      cast((cast(airtime as float) - -3818) * 0.001638001638001638 as int)\n    end\n    AS key0, case when\n      distance >= 4983\n    then\n      11\n    else\n      cast((cast(distance as float) - 0) * 0.002408187838651415 as int)\n    end\n    AS key1, COUNT(*) AS val FROM flights WHERE ((airtime >= -3818 AND airtime <= 3508) OR (airtime IS NULL)) AND ((distance >= 0 AND distance <= 4983) OR (distance IS NULL)) GROUP BY key0, key1 HAVING (key0 >= 0 AND key0 < 12 OR key0 IS NULL) AND (key1 >= 0 AND key1 < 12 OR key1 IS NULL) ORDER BY val DESC LIMIT 10"
   );
 
   assert.equal(
@@ -142,7 +142,7 @@ tape("writeSQL", assert => {
         }
       ]
     }),
-    "SELECT date_trunc(year, CAST(contrib_date AS TIMESTAMP(0))) as key0, AVG(amount) as series_1 FROM contributions WHERE (CAST(contrib_date AS TIMESTAMP(0)) BETWEEN TIMESTAMP(0) '1996-11-05 17:47:30' AND TIMESTAMP(0) '2010-10-21 10:54:07') AND (amount IS NOT NULL) GROUP BY key0 ORDER BY key0"
+    "SELECT date_trunc(year, CAST(contrib_date AS TIMESTAMP(0))) AS key0, AVG(amount) AS series_1 FROM contributions WHERE (CAST(contrib_date AS TIMESTAMP(0)) BETWEEN TIMESTAMP(0) '1996-11-05 17:47:30' AND TIMESTAMP(0) '2010-10-21 10:54:07') AND (amount IS NOT NULL) GROUP BY key0 ORDER BY key0"
   );
 
   assert.equal(
@@ -174,7 +174,7 @@ tape("writeSQL", assert => {
       children: [],
       transform: []
     }),
-    "SELECT * FROM flights JOIN zipcode as table1 JOIN contrib as table2"
+    "SELECT * FROM flights JOIN zipcode AS table1 JOIN contrib AS table2"
   );
 
   assert.equal(
@@ -190,6 +190,6 @@ tape("writeSQL", assert => {
         ...rel.top("key0", 10)
       ]
     }),
-    "SELECT carrier_name as key0, COUNT(*) as val, MAX(delay) as color FROM flights WHERE (delay BETWEEN -50 AND 50) GROUP BY key0 ORDER BY key0 DESC LIMIT 10"
+    "SELECT carrier_name AS key0, COUNT(*) AS val, MAX(delay) AS color FROM flights WHERE (delay BETWEEN -50 AND 50) GROUP BY key0 ORDER BY key0 DESC LIMIT 10"
   );
 });


### PR DESCRIPTION
Normalize all SQL building in data-layer to use uppercase AS for table and column aliases, to be consistent with Immerse and other modules.