### PR TITLE
[FE-11992] Update parse-sample to use new SAMPLE_RATIO function

### DIFF
--- a/packages/data-layer/tests/parser/parse-transform.spec.js
+++ b/packages/data-layer/tests/parser/parse-transform.spec.js
@@ -134,7 +134,7 @@ tape("sample", assert => {
     {
       select: [],
       from: "taxis",
-      where: ["MOD( MOD (taxis.rowid, 2147483648) * 2654435761 , 4294967296) < 12469954"],
+      where: ["SAMPLE_RATIO(0.002903387524200134)"],
       groupby: [],
       having: [],
       orderby: [],


### PR DESCRIPTION
Update parse-sample to use the more performant SAMPLE_RATIO function just added to OmniSciDB, instead of a manual hash.

Before (both are filters in the SQL WHERE clause):
```
MOD( MOD (taxis.rowid, 2147483648) * 2654435761 , 4294967296) < 12469954
```

After:
```
SAMPLE_RATIO(0.002903387524200134)
```

The parameter to SAMPLE_RATIO is a number from 0.0-1.0 representing a probability the row will be in the results. In this case, about 0.2% of the rows will make it through. The prior sampling expression did this too, as a result of the ratio used for the rowid multiplier - so the above should be equivalent in effect.